### PR TITLE
Add gradle-info metadata to pom files

### DIFF
--- a/src/main/groovy/nebula/plugin/responsible/NebulaPublishManifestPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/responsible/NebulaPublishManifestPlugin.groovy
@@ -53,7 +53,7 @@ import org.gradle.api.publish.maven.MavenPublication
  *
  * @author J. Michael McGarr
  */
-class NebulaMetadataPlugin implements Plugin<Project> {
+class NebulaPublishManifestPlugin implements Plugin<Project> {
 
     protected Project project
 

--- a/src/main/resources/META-INF/gradle-plugins/nebula-metadata.properties
+++ b/src/main/resources/META-INF/gradle-plugins/nebula-metadata.properties
@@ -1,1 +1,0 @@
-implementation-class=nebula.plugin.responsible.NebulaMetadataPlugin

--- a/src/main/resources/META-INF/gradle-plugins/nebula-publish-manifest.properties
+++ b/src/main/resources/META-INF/gradle-plugins/nebula-publish-manifest.properties
@@ -1,0 +1,1 @@
+implementation-class=nebula.plugin.responsible.NebulaPublishManifestPlugin

--- a/src/test/groovy/nebula/plugin/responsible/NebulaPublishManifestPluginLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/responsible/NebulaPublishManifestPluginLauncherSpec.groovy
@@ -2,7 +2,7 @@ package nebula.plugin.responsible
 
 import nebula.test.IntegrationSpec
 
-class NebulaMetadataPluginLauncherSpec extends IntegrationSpec {
+class NebulaPublishManifestPluginLauncherSpec extends IntegrationSpec {
 
     String mavenLocal = "${System.env['HOME']}/.m2/repository"
 
@@ -15,7 +15,7 @@ class NebulaMetadataPluginLauncherSpec extends IntegrationSpec {
             apply plugin: 'java'
             apply plugin: 'info'
             apply plugin: 'nebula-publishing'
-            apply plugin: 'nebula-metadata'
+            apply plugin: 'nebula-publish-manifest'
 
             group = 'nebula.hello'
             version = '1.0'

--- a/src/test/groovy/nebula/plugin/responsible/NebulaPublishManifestPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/responsible/NebulaPublishManifestPluginSpec.groovy
@@ -2,12 +2,12 @@ package nebula.plugin.responsible
 
 import spock.lang.Specification
 
-class NebulaMetadataPluginSpec extends Specification {
+class NebulaPublishManifestPluginSpec extends Specification {
 
-    NebulaMetadataPlugin plugin
+    NebulaPublishManifestPlugin plugin
 
     def setup() {
-        this.plugin = new NebulaMetadataPlugin()
+        this.plugin = new NebulaPublishManifestPlugin()
     }
 
     void "passes valid name"() {


### PR DESCRIPTION
Add a new plugin (nebula-metadata) that will pull data from gradle-info and insert the key/value pairs into the published pom file's <properties/> node.  The key's are prefixed with 'nebula.' to avoid collision and confusion with an existing properties.

The particular implement is the simplest path, but also likely the least desirable.  It results in a pom file that has a bunch of properties that may look foreign to somebody accustomed to maven pom's.  An alternative approach would be to add a new namespace (assuming that is possible) to the pom.xml.

Here's an example of the resulting pom file.

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>nebula.hello</groupId>
  <artifactId>world</artifactId>
  <version>1.0</version>
  <dependencies>
    <dependency>
      <groupId>asm</groupId>
      <artifactId>asm</artifactId>
      <version>3.1</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
  <properties>
    <nebula.Manifest-Version>1.0</nebula.Manifest-Version>
    <nebula.Implementation-Title>nebula.hello#world;1.0</nebula.Implementation-Title>
    <nebula.Implementation-Version>1.0</nebula.Implementation-Version>
    <nebula.Built-Status>integration</nebula.Built-Status>
    <nebula.Built-By>mmcgarr</nebula.Built-By>
    <nebula.Build-Date>2014-07-03_15:33:43</nebula.Build-Date>
    <nebula.Gradle-Version>1.12-20140608201532+0000</nebula.Gradle-Version>
    <nebula.Module-Source>/build/test/nebula.plugin.responsible.NebulaMetadataPluginLauncherSpec/published-pom-contains-a-collected-property</nebula.Module-Source>
    <nebula.Module-Origin>git@github.com:nebula-plugins/nebula-project-plugin.git</nebula.Module-Origin>
    <nebula.Change>0ab9baf</nebula.Change>
    <nebula.Build-Host>localhost</nebula.Build-Host>
    <nebula.Build-Job>LOCAL</nebula.Build-Job>
    <nebula.Build-Number>LOCAL</nebula.Build-Number>
    <nebula.Build-Id>LOCAL</nebula.Build-Id>
    <nebula.Created-By>1.7.0_51-b13 (Oracle Corporation)</nebula.Created-By>
    <nebula.Build-Java-Version>1.7.0_51</nebula.Build-Java-Version>
    <nebula.X-Compile-Target-JDK>1.7</nebula.X-Compile-Target-JDK>
    <nebula.X-Compile-Source-JDK>1.7</nebula.X-Compile-Source-JDK>
  </properties>
</project>
```
