### PR TITLE
Append to the facet runtime classpath.

### DIFF
--- a/src/main/groovy/nebula/plugin/responsible/NebulaFacetPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/responsible/NebulaFacetPlugin.groovy
@@ -110,7 +110,7 @@ class NebulaFacetPlugin implements Plugin<Project> {
         sourceSets.create(set.name) {
             compileClasspath += parentSourceSet.output
             compileClasspath += parentSourceSet.compileClasspath
-            runtimeClasspath = it.output + it.compileClasspath
+            runtimeClasspath += it.output + it.compileClasspath
         }
     }
 


### PR DESCRIPTION
Appending instead of replacing allows integTestRuntime dependencies to take
effect.