### PR TITLE
Set test facets' parent source set to test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ That will cause the functionalCompile to extend from testCompile, and functional
 Test Facets
 --------------
 
-If "Test" is in the facet name, then a Test task would be created (though it'll still inherit from the "main" SourceSet, use the above configuration to make the test facet extends from the test SourceSet). For example:
+If "Test" is in the facet name, then a Test task would be created which will inherit from the "test" SourceSet unless configured otherwise. For example:
 
     facets {
         integTest

--- a/src/main/groovy/nebula/plugin/responsible/FacetDefinition.groovy
+++ b/src/main/groovy/nebula/plugin/responsible/FacetDefinition.groovy
@@ -19,7 +19,10 @@ class FacetDefinition implements Named {
     String parentSourceSet
 
     def getParentSourceSet() {
-        return parentSourceSet ?: 'main'
+        return parentSourceSet ?: this.defaultParentSourceSet
     }
 
+    protected getDefaultParentSourceSet() {
+        return 'main'
+    }
 }

--- a/src/main/groovy/nebula/plugin/responsible/TestFacetDefinition.groovy
+++ b/src/main/groovy/nebula/plugin/responsible/TestFacetDefinition.groovy
@@ -27,4 +27,9 @@ class TestFacetDefinition extends FacetDefinition {
      * Whether the task created for the test facet should be a dependency of 'check'.
      */
     boolean includeInCheckLifecycle = true
+
+    @Override
+    protected getDefaultParentSourceSet() {
+        return 'test'
+    }
 }

--- a/src/test/groovy/nebula/plugin/responsible/NebulaFacetPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/responsible/NebulaFacetPluginSpec.groovy
@@ -39,10 +39,10 @@ class NebulaFacetPluginSpec extends PluginProjectSpec {
         project.configurations.size() == 25
         def compileConf = project.configurations.getByName('integTestCompile')
         compileConf
-        compileConf.extendsFrom.any { it.name == 'compile'}
+        compileConf.extendsFrom.any { it.name == 'testCompile'}
         def runtimeConf = project.configurations.getByName('integTestRuntime')
         runtimeConf
-        runtimeConf.extendsFrom.any { it.name == 'runtime'}
+        runtimeConf.extendsFrom.any { it.name == 'testRuntime'}
     }
 
     def 'create multiple source sets'() {
@@ -93,7 +93,24 @@ class NebulaFacetPluginSpec extends PluginProjectSpec {
         def compileConf = project.configurations.getByName('examplesCompile')
         compileConf
         compileConf.extendsFrom.any { it.name == 'testCompile'}
+    }
 
+    def 'configure test facet'() {
+        when:
+        project.apply plugin: 'java'
+        project.apply plugin: NebulaFacetPlugin.class
+        project.facets {
+            examplesTest {
+                parentSourceSet = 'main'
+            }
+        }
+
+        then:
+        project.sourceSets.size() == 3
+
+        def compileConf = project.configurations.getByName('examplesTestCompile')
+        compileConf
+        compileConf.extendsFrom.any { it.name == 'compile'}
     }
 
     def 'test based facet'() {
@@ -122,5 +139,37 @@ class NebulaFacetPluginSpec extends PluginProjectSpec {
         project.tasks.getByName('check').dependsOn.any {
             it instanceof Task && ((Task) it).name == 'performanceTest'
         }
+    }
+
+    def 'default parent sourceset is main'() {
+        when:
+        project.apply plugin: 'java'
+        project.apply plugin: NebulaFacetPlugin.class
+        project.facets {
+            examples
+        }
+
+        then:
+        project.sourceSets.size() == 3
+
+        def compileConf = project.configurations.getByName('examplesCompile')
+        compileConf
+        compileConf.extendsFrom.any { it.name == 'compile' }
+    }
+
+    def 'default parent sourceset for tests is test'() {
+        when:
+        project.apply plugin: 'java'
+        project.apply plugin: NebulaFacetPlugin.class
+        project.facets {
+            examplesTest
+        }
+
+        then:
+        project.sourceSets.size() == 3
+
+        def compileConf = project.configurations.getByName('examplesTestCompile')
+        compileConf
+        compileConf.extendsFrom.any { it.name == 'testCompile' }
     }
 }


### PR DESCRIPTION
Gives FacetDefinition a new defaultParentSourceSet property,
which is overridden in TestFacetDefinition.

See nebula-plugins#24 for discussion.
