### PR TITLE
Remove support on Test task for older versions of gradle

### DIFF
--- a/src/main/groovy/nebula/plugin/responsible/NebulaFacetPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/responsible/NebulaFacetPlugin.groovy
@@ -95,13 +95,9 @@ class NebulaFacetPlugin implements Plugin<Project> {
         Test task = project.tasks.create(testName, Test)
         task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
         task.description("Runs the ${sourceSet.name} tests")
-        task.reports.html.destination = new File("${project.buildDir}/reports/${sourceSet.name}")
-        task.reports.junitXml.destination = new File("${project.buildDir}/${sourceSet.name}-results")
-        if (GradleKt.versionLessThan(project.gradle, "4.0")) {
-            task.testClassesDir = sourceSet.output.classesDir
-        } else {
-            task.testClassesDirs = sourceSet.output.classesDirs
-        }
+        task.reports.html.setDestination(new File("${project.buildDir}/reports/${sourceSet.name}"))
+        task.reports.junitXml.setDestination(new File("${project.buildDir}/${sourceSet.name}-results"))
+        task.testClassesDirs = sourceSet.output.classesDirs
         task.classpath = sourceSet.runtimeClasspath
         task
     }


### PR DESCRIPTION
Going forward, I think we should be able to remove support for Gradle < 4.0 projects since Nebula tries to keep up to date with Gradle versions. Gradle 5 is expected to remove `testClassesDir`. Also this should help to avoid warnings related to:

```
The setTestClassesDir(File) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the setTestClassesDirs(FileCollection) method instead.
```

Looking at the current code in Gradle 5 Nighty builds, seems that `testClassesDir` is not removed yet, but I'm pretty sure this could change soon.

I think this is also related to https://github.com/nebula-plugins/nebula-project-plugin/issues/42

Let me know your thoughts
