### PR TITLE
NebulaFacetPlugin: navigate sourceset/configuration hierarchies to add source outputs to facet classpaths

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/nebula/plugin/responsible/NebulaFacetPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/responsible/NebulaFacetPlugin.groovy
@@ -12,23 +12,22 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
-import org.gradle.api.internal.file.UnionFileCollection
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.SourceSetOutput
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
 import org.gradle.internal.reflect.Instantiator
 
 @CompileStatic
 class NebulaFacetPlugin implements Plugin<Project> {
+
+    private static final String IMPLEMENTATION_CONFIG_NAME = 'implementation'
+    private static final String MAIN_SOURCE_SET_NAME = 'main'
 
     Project project
     NamedDomainObjectContainer<FacetDefinition> extension
@@ -62,11 +61,11 @@ class NebulaFacetPlugin implements Plugin<Project> {
                     // Since we're using NamedContainerProperOrder, we're configured already.
                     SourceSet sourceSet = createSourceSet(parentSourceSet, facet)
 
-                    Configuration parentCompile = project.configurations.getByName(parentSourceSet.compileClasspathConfigurationName)
-                    project.configurations.getByName(sourceSet.compileClasspathConfigurationName).extendsFrom(parentCompile)
+                    Configuration parentImplementation = project.configurations.getByName(parentSourceSet.implementationConfigurationName)
+                    project.configurations.getByName(sourceSet.implementationConfigurationName).extendsFrom(parentImplementation)
 
-                    Configuration parentRuntime = project.configurations.getByName(parentSourceSet.runtimeClasspathConfigurationName)
-                    project.configurations.getByName(sourceSet.runtimeClasspathConfigurationName).extendsFrom(parentRuntime)
+                    Configuration parentRuntimeOnly = project.configurations.getByName(parentSourceSet.runtimeOnlyConfigurationName)
+                    project.configurations.getByName(sourceSet.runtimeOnlyConfigurationName).extendsFrom(parentRuntimeOnly)
 
                     Configuration annotationProcessor = project.configurations.getByName(parentSourceSet.annotationProcessorConfigurationName)
                     project.configurations.getByName(sourceSet.annotationProcessorConfigurationName).extendsFrom(annotationProcessor)
@@ -143,8 +142,7 @@ class NebulaFacetPlugin implements Plugin<Project> {
             //e.g smokeTest inherits from test which inherits from main and we need to see classes from main
             Set<Object> compileClasspath = new LinkedHashSet<Object>()
             compileClasspath.add(sourceSet.compileClasspath)
-            compileClasspath.add(parentSourceSet.output)
-            compileClasspath.addAll(extractAllOutputs(parentSourceSet.compileClasspath))
+            addParentSourceSetOutputs(compileClasspath, parentSourceSet, sourceSets)
 
             //we are using from to create ConfigurableFileCollection so if we keep inhering from created facets we can
             //still extract chain of output from all parents
@@ -152,24 +150,24 @@ class NebulaFacetPlugin implements Plugin<Project> {
             //runtime classpath of parent already has parent output so we don't need to explicitly add it
             Set<Object> runtimeClasspath = new LinkedHashSet<Object>()
             runtimeClasspath.add(sourceSet.runtimeClasspath)
-            runtimeClasspath.addAll(extractAllOutputs(parentSourceSet.runtimeClasspath))
+            addParentSourceSetOutputs(runtimeClasspath, parentSourceSet, sourceSets)
 
             sourceSet.runtimeClasspath = project.objects.fileCollection().from(runtimeClasspath as Object[])
         }
     }
 
-    private static Set<Object> extractAllOutputs(FileCollection classpath) {
-        if (classpath instanceof ConfigurableFileCollection) {
-            (classpath as ConfigurableFileCollection).from.findAll {it instanceof FileCollection }. collectMany { extractAllOutputs(it as FileCollection) } as Set<Object>
+    private void addParentSourceSetOutputs( Set<Object> classpath, SourceSet parentSourceSet, SourceSetContainer sourceSets) {
+        classpath.add(parentSourceSet.output)
+        Configuration parentSourceSetImplementationConfiguration = project.configurations.findByName(parentSourceSet.implementationConfigurationName)
+        if(!parentSourceSetImplementationConfiguration || !parentSourceSetImplementationConfiguration.extendsFrom) {
+            return
         }
-        else if (classpath instanceof UnionFileCollection) {
-            (classpath as UnionFileCollection).sources.collectMany { extractAllOutputs(it) } as Set<Object>
-        }
-        else if (classpath instanceof SourceSetOutput) {
-            [classpath] as Set<Object>
-        }
-        else {
-            new LinkedHashSet<Object>()
+
+        Configuration extendsFrom = parentSourceSetImplementationConfiguration.extendsFrom.find()
+        if(extendsFrom.name == IMPLEMENTATION_CONFIG_NAME) {
+            addParentSourceSetOutputs(classpath, sourceSets.getByName(MAIN_SOURCE_SET_NAME), sourceSets)
+        } else {
+            addParentSourceSetOutputs(classpath, sourceSets.getByName(extendsFrom.name.replaceAll(IMPLEMENTATION_CONFIG_NAME.capitalize(), '')), sourceSets)
         }
     }
 

--- a/src/test/groovy/nebula/plugin/responsible/NebulaFacetPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/responsible/NebulaFacetPluginSpec.groovy
@@ -45,12 +45,12 @@ class NebulaFacetPluginSpec extends PluginProjectSpec {
             assert project.configurations.size() == 22
         }
 
-        def compileConf = project.configurations.getByName('integTestCompileClasspath')
-        compileConf
-        compileConf.extendsFrom.any { it.name == 'compileClasspath'}
-        def runtimeConf = project.configurations.getByName('integTestRuntimeClasspath')
-        runtimeConf
-        runtimeConf.extendsFrom.any { it.name == 'runtimeClasspath'}
+        def integTestImplementationConf = project.configurations.getByName('integTestImplementation')
+        integTestImplementationConf
+        integTestImplementationConf.extendsFrom.any { it.name == 'implementation'}
+        def integTestRuntimeOnlyConf = project.configurations.getByName('integTestRuntimeOnly')
+        integTestRuntimeOnlyConf
+        integTestRuntimeOnlyConf.extendsFrom.any { it.name == 'runtimeOnly'}
     }
 
     def 'create multiple source sets'() {
@@ -98,9 +98,9 @@ class NebulaFacetPluginSpec extends PluginProjectSpec {
         then:
         project.sourceSets.size() == 3
 
-        def compileConf = project.configurations.getByName('examplesCompileClasspath')
-        compileConf
-        compileConf.extendsFrom.any { it.name == 'testCompileClasspath'}
+        def examplesImplementationConf = project.configurations.getByName('examplesImplementation')
+        examplesImplementationConf
+        examplesImplementationConf.extendsFrom.any { it.name == 'testImplementation'}
 
     }
 }


### PR DESCRIPTION
We learned the following from Gradle 7.2 -> 7.3

We noticed that our facet plugin started failing with 7.3 nightly. This is something similar to what that plugin does: https://github.com/nebula-plugins/gradle-nebula-integration/blob/master/sourcesets-issues-gradle-7_3/buildSrc/src/main/groovy/nebula/MySourceSetPlugin.groovy#L94-L131  where basically we create source sets that extend others. This way we can introduce things like integrationTest / smokeTest/ you name it.

7.2

```
result = {DefaultConfigurableFileCollection$PathSet@10973}  size = 2
 0 = {DefaultSourceSetOutput_Decorated@11010} 
 1 = {DefaultConfiguration_Decorated@11011} 
```

vs 7.3

```
result = {DefaultConfigurableFileCollection$PathSet@10188}  size = 2
 0 = {JvmTestSuitePlugin$lambda@10191} 
 1 = {DefaultConfiguration_Decorated@10192} 
```

We have some logic to collect the sourceset outputs per https://github.com/nebula-plugins/gradle-nebula-
integration/blob/master/sourcesets-issues-gradle-7_3/buildSrc/src/main/groovy/nebula/MySourceSetPlugin.groovy#L124 

We learned that a Testing Suite plugin is coming in Gradle 7.3: https://github.com/gradle/gradle/blob/master/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesDependenciesIntegrationTest.groovy#L162-L174 

We got two suggestions from Gradle folks:

* Instead of extending the xxxClasspath configurations between source sets, you could extend their implementation and runtimeOnly. This matches what the test source set does with the main source set.
* Instead of looking at the parent source set's compileClasspath/runtimeClasspath at all, you could duplicate what the Java plugin does, which is to add the main and test source set outputs to the classpath.

This was great insight. Unfortunately, we need to navigate the hierarchy in oder to add the proper source set outputs so adding the output from the parent only is not enough.

This PR addresses the sourceset output logic by navigating the hierarchy for the facet that is configuring. For example, if we have `main` -> `test` -> `smokeTest`, it will get the information of outputs from `main` and `test` in order to add them to the `smokeTest` compile and runtime classpaths.